### PR TITLE
Fork wslay and change submodule URI

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,4 +9,4 @@
 	url = https://github.com/tarantool/xtm.git
 [submodule "third_party/wslay"]
 	path = third_party/wslay
-	url = https://github.com/tatsuhiro-t/wslay.git
+	url = https://github.com/tarantool/wslay.git


### PR DESCRIPTION
Changed URL of wslay to tarantool fork repo.

Closes #14