### PR TITLE
check shuttle_size is large enough for Lua handlers

### DIFF
--- a/httpng/httpng.c
+++ b/httpng/httpng.c
@@ -2467,6 +2467,11 @@ Skip_main_lua_handler:
 		lerr = "No handlers specified";
 		goto no_handlers;
 	}
+	if (lua_site_count != 0 &&
+	    shuttle_size < sizeof(shuttle_t) + sizeof(lua_response_t)) {
+		lerr = "shuttle_size is too small for Lua handlers";
+		goto no_handlers;
+	}
 	unsigned short port = DEFAULT_LISTEN_PORT;
 	lua_getfield(L, LUA_STACK_IDX_TABLE, "listen");
 	if (lua_isnil(L, -1))

--- a/tests/shuttle_size.lua
+++ b/tests/shuttle_size.lua
@@ -1,0 +1,13 @@
+local t = require('luatest')
+local g = t.group('shuttle_size')
+local http = require 'httpng'
+
+--[[ There is no point testing other values - parameters are automatically
+saturated for MIN and MAX, only shuttle_size with Lua handlers is "special"
+(MIN_shuttle_size is enough for C handlers)
+--]]--
+g.test_small_for_lua = function()
+    t.assert_error_msg_content_equals('shuttle_size is too small for Lua handlers',
+        http.cfg, { shuttle_size = 64, handler = function() end })
+end
+


### PR DESCRIPTION
Existing "saturating" checks for MIN/MAX allow small shuttle_size
which may be enough for some C handlers but not for Lua handlers.

Part of #7