### PR TITLE
asan can be enabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,54 @@ set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
 set(CMAKE_INCLUDE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake"
     ${CMAKE_INCLUDE_PATH})
 
+include(CheckCSourceCompiles)
+
+macro(add_compile_flags langs)
+    foreach(_lang ${langs})
+        string (REPLACE ";" " " _flags "${ARGN}")
+        set ("CMAKE_${_lang}_FLAGS" "${CMAKE_${_lang}_FLAGS} ${_flags}")
+        unset (${_lang})
+        unset (${_flags})
+    endforeach()
+endmacro(add_compile_flags)
+
+option(ENABLE_ASAN "Enable AddressSanitizer, a fast memory error detector based on compiler instrumentation" OFF)
+if (ENABLE_ASAN)
+    if (CMAKE_COMPILER_IS_GNUCC)
+        message(FATAL_ERROR
+            "\n"
+            " Tarantool does not support GCC's AddressSanitizer. Use clang:\n"
+            " $ git clean -xfd; git submodule foreach --recursive git clean -xfd\n"
+            " $ CC=clang CXX=clang++ cmake . -DENABLE_ASAN=ON && make -j\n"
+            "\n")
+    endif()
+
+    set(CMAKE_REQUIRED_FLAGS "-fsanitize=address -fsanitize-blacklist=${CMAKE_SOURCE_DIR}/asan/asan.supp")
+    check_c_source_compiles("int main(void) {
+        #include <sanitizer/asan_interface.h>
+        void *x;
+	    __sanitizer_finish_switch_fiber(x);
+        return 0;
+        }" ASAN_INTERFACE_OLD)
+    check_c_source_compiles("int main(void) {
+        #include <sanitizer/asan_interface.h>
+        void *x;
+	    __sanitizer_finish_switch_fiber(x, 0, 0);
+        return 0;
+    }" ASAN_INTERFACE_NEW)
+    set(CMAKE_REQUIRED_FLAGS "")
+
+    if (ASAN_INTERFACE_OLD)
+        add_definitions(-DASAN_INTERFACE_OLD=1)
+    elseif (ASAN_INTERFACE_NEW)
+        add_definitions(-UASAN_INTERFACE_OLD)
+    else()
+        message(FATAL_ERROR "Cannot enable AddressSanitizer")
+    endif()
+
+    add_compile_flags("C;CXX" -fsanitize=address -fsanitize-blacklist=${CMAKE_SOURCE_DIR}/asan/asan.supp)
+endif()
+
 # Find Tarantool and Lua dependecies
 set(TARANTOOL_FIND_REQUIRED ON)
 find_package(Tarantool REQUIRED)

--- a/asan/asan.supp
+++ b/asan/asan.supp
@@ -1,0 +1,6 @@
+# All exceptions are under control of the issue:
+# https://github.com/tarantool/tarantool/issues/4360
+#
+# File format:
+#fun:*
+#src:*


### PR DESCRIPTION
This obviously requires tarantool binary itself to be built with
enabled ASAN.

CC=clang CXX=clang++ cmake -DENABLE_ASAN=ON .