### PR TITLE
openssl security level is configurable

### DIFF
--- a/tests/wrong_config.lua
+++ b/tests/wrong_config.lua
@@ -90,6 +90,16 @@ g.test_min_proto_version_invalid = function()
         http.cfg, { handler = function() end, min_proto_version = 'ssl2' })
 end
 
+g.test_level_nan = function()
+    t.assert_error_msg_content_equals('openssl_security_level is not a number',
+        http.cfg, { handler = function() end, openssl_security_level = 'ssl' })
+end
+
+g.test_level_invalid = function()
+    t.assert_error_msg_content_equals('openssl_security_level is invalid',
+        http.cfg, { handler = function() end, openssl_security_level = 6 })
+end
+
 g.test_simple = function()
     http.cfg( { handler = function() end } )
 end


### PR DESCRIPTION
openssl_security_limit, defaults to 1 (which is typical default
for OpenSSL),
https://www.openssl.org/docs/man1.1.1/man3/SSL_CTX_set_security_level.html

Now you can benchmark certificates with small RSA keys as much
as you want or tighten security to the sky.