### PR TITLE
fix libh2o-evloop build and unutilized variable

### DIFF
--- a/httpng/httpng.c
+++ b/httpng/httpng.c
@@ -1542,6 +1542,7 @@ lua_fiber_func(va_list ap)
 	lua_State *const L = va_arg(ap, lua_State *);
 
 	lua_response_t *const response = (lua_response_t *)&shuttle->payload;
+	thread_ctx_t *const thread_ctx = shuttle->thread_ctx;
 
 	/* User handler function, written in Lua. */
 	lua_rawgeti(L, LUA_REGISTRYINDEX, response->un.req.lua_handler_ref);
@@ -1593,7 +1594,6 @@ lua_fiber_func(va_list ap)
 	lua_createtable(L, 0, 2);
 	lua_setfield(L, -2, "headers");
 
-	thread_ctx_t *const thread_ctx = shuttle->thread_ctx;
 	if (lua_pcall(L, 2, 1, 0) != LUA_OK) {
 		/* FIXME: Should probably log this instead(?) */
 		fprintf(stderr, "User handler for \"\%s\" failed with error "


### PR DESCRIPTION
fix uninitialized variable

Caught when building on macOS:
```
$ make -j
...
[100%] Building C object CMakeFiles/httpng.dir/httpng/httpng.c.o
/Users/a.starshov/httpng/httpng/httpng.c:1572:6: error: variable 'thread_ctx' is used uninitialized whenever 'if' condition is true
      [-Werror,-Wsometimes-uninitialized]
        if (fill_received_headers_and_body(L, shuttle)) {
            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/a.starshov/httpng/httpng/httpng.c:1643:8: note: uninitialized use occurs here
        if (--thread_ctx->active_lua_fibers == 0 &&
              ^~~~~~~~~~
/Users/a.starshov/httpng/httpng/httpng.c:1572:2: note: remove the 'if' if its condition is always false
        if (fill_received_headers_and_body(L, shuttle)) {
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/a.starshov/httpng/httpng/httpng.c:1596:2: note: variable 'thread_ctx' is declared here
        thread_ctx_t *const thread_ctx = shuttle->thread_ctx;
```

Also: updated h2o submodule to version buildable on MacOS with recent changes.