### PR TITLE
shutdown is now available as lua function

### DIFF
--- a/examples/multiple.lua
+++ b/examples/multiple.lua
@@ -367,6 +367,7 @@ local lua_sites = {
 }
 
 print '\n\n\nFilling in test spaces completed, launching HTTP server...\n\n'
+::restart::
 init_func({
     threads = 4,
     max_conn_per_thread = 64,
@@ -378,3 +379,11 @@ init_func({
     },
     sites = lua_sites,
 })
+
+fiber.sleep(10)
+print '\n\n\nStopping HTTP server...\n\n'
+httpng_lib.shutdown()
+print '\n\n\nSleeping...\n\n'
+fiber.sleep(1)
+print '\n\n\nLaunching again...\n\n'
+goto restart

--- a/httpng/httpng.c
+++ b/httpng/httpng.c
@@ -3146,6 +3146,7 @@ unsigned get_shuttle_size(void)
 
 static const struct luaL_Reg mylib[] = {
 	{"cfg", cfg},
+	{"shutdown", on_shutdown},
 	{NULL, NULL}
 };
 


### PR DESCRIPTION
N. b.: there are still stability issues, especially if evloop is used
(and it is used by default). There is also file descriptor leak issue
which is visible when HTTP server is shut down and launched again
numerous times.

examples/multiple.lua now does exactly that.

Part of #6