### PR TITLE
add cross-platform semaphores

### DIFF
--- a/httpng/httpng_sem.h
+++ b/httpng/httpng_sem.h
@@ -1,0 +1,55 @@
+#ifndef HTTPNG_SEM_H
+#define HTTPNG_SEM_H
+
+#ifdef __APPLE__
+#include <dispatch/dispatch.h>
+typedef dispatch_semaphore_t httpng_sem_t;
+#else /* __APPLE__ */
+#include <semaphore.h>
+typedef sem_t httpng_sem_t;
+#endif /* __APPLE__ */
+
+static inline void
+httpng_sem_init(httpng_sem_t *s, uint32_t value)
+{
+#ifdef __APPLE__
+	*s = dispatch_semaphore_create(value);
+#else /* __APPLE__ */
+	sem_init(s, 0, value);
+#endif /* __APPLE__ */
+}
+
+static inline void
+httpng_sem_wait(httpng_sem_t *s)
+{
+#ifdef __APPLE__
+	dispatch_semaphore_wait(*s, DISPATCH_TIME_FOREVER);
+#else /* __APPLE__ */
+	int r;
+	do {
+		r = sem_wait(s);
+	} while (r == -1 && errno == EINTR);
+#endif /* __APPLE__ */
+}
+
+static inline void
+httpng_sem_post(httpng_sem_t *s)
+{
+#ifdef __APPLE__
+	dispatch_semaphore_signal(*s);
+#else /* __APPLE__ */
+	sem_post(s);
+#endif /* __APPLE__ */
+}
+
+static inline void
+httpng_sem_destroy(httpng_sem_t *s)
+{
+#ifdef __APPLE__
+	dispatch_release(*s);
+#else /* __APPLE__ */
+	sem_destroy(s);
+#endif /* __APPLE__ */
+}
+
+#endif /* HTTPNG_SEM_H */


### PR DESCRIPTION
macOS Catalina 10.15.7:
```
$ make
...
Scanning dependencies of target httpng
[100%] Building C object CMakeFiles/httpng.dir/httpng/httpng.c.o
/Users/a.starshov/httpng/httpng/httpng.c:2472:2: error: 'sem_destroy' is deprecated [-Werror,-Wdeprecated-declarations]
        sem_destroy(&thread_ctx->can_be_terminated);
        ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.1.sdk/usr/include/sys/semaphore.h:53:26: note: 'sem_destroy' has been
      explicitly marked deprecated here
int sem_destroy(sem_t *) __deprecated;
                         ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.1.sdk/usr/include/sys/cdefs.h:196:40: note: expanded from macro
      '__deprecated'
#define __deprecated    __attribute__((__deprecated__))
                                       ^
/Users/a.starshov/httpng/httpng/httpng.c:3108:3: error: 'sem_init' is deprecated [-Werror,-Wdeprecated-declarations]
                sem_init(&thread_ctx->can_be_terminated, 0, 0);
                ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.1.sdk/usr/include/sys/semaphore.h:55:42: note: 'sem_init' has been
      explicitly marked deprecated here
int sem_init(sem_t *, int, unsigned int) __deprecated;
                                         ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.1.sdk/usr/include/sys/cdefs.h:196:40: note: expanded from macro
      '__deprecated'
#define __deprecated    __attribute__((__deprecated__))
                                       ^
2 errors generated.
make[2]: *** [CMakeFiles/httpng.dir/httpng/httpng.c.o] Error 1
make[1]: *** [CMakeFiles/httpng.dir/all] Error 2
make: *** [all] Error 2

```
POSIX semaphores are deprecated on macOS, so used a wrapper `httpng_semaphore_t`.
Now, for macOS dispatch_semaphore_t is used, POSIX sem_t for others.