### PR TITLE
disable write ahead logs for examples

### DIFF
--- a/examples/benchmark_query.lua
+++ b/examples/benchmark_query.lua
@@ -1,5 +1,6 @@
 box.cfg{
     listen = 3306,
+    wal_mode = 'none',
 }
 
 local s = box.schema.space.create('tester')

--- a/examples/multiple.lua
+++ b/examples/multiple.lua
@@ -7,6 +7,7 @@ require('strict')
 print '\n\n\n\n\nFilling in test spaces, please wait...\n\n\n'
 box.cfg{
     listen = 3306,
+    wal_mode = 'none',
 }
 
 local s = box.schema.space.create('tester')


### PR DESCRIPTION
Less garbage in working copy