### PR TITLE
hot reload prototype (handler only)

### DIFF
--- a/examples/hot_reload_handler.lua
+++ b/examples/hot_reload_handler.lua
@@ -1,0 +1,35 @@
+local http = require 'httpng'
+local fiber = require 'fiber'
+
+local foo_handler = function(req, io)
+    return {
+        status = 200,
+        body = 'foo',
+    }
+end
+
+local bar_handler = function(req, io)
+    return {
+        status = 200,
+        body = 'bar',
+    }
+end
+
+local config = {
+    threads = 4,
+    listen =  { { port = 8080 } },
+}
+
+::again::
+
+print 'Using foo..'
+config.handler = foo_handler;
+http.cfg(config)
+fiber.sleep(0.1)
+
+print 'Using bar..'
+config.handler = bar_handler;
+http.cfg(config)
+
+fiber.sleep(0.1)
+goto again


### PR DESCRIPTION
cfg() can be called w/o calling shutdown(), it would replace
Lua handler (only for "/" and only if it is specified as "handler"
and not in "sites" array). Everything else is ignored and not even
checked for sanity.

Part of #18