### PR TITLE
shutdown() returns error if already in progress

### DIFF
--- a/httpng/httpng.c
+++ b/httpng/httpng.c
@@ -2705,6 +2705,8 @@ static int on_shutdown_internal(lua_State *L, bool called_from_callback)
 	if (!conf.configured)
 		return luaL_error(L, "Server is not launched");
 	if (conf.is_shutdown_in_progress) {
+		if (!called_from_callback)
+			return luaL_error(L, "on_shutdown() is already in progress");
 		fprintf(stderr,
 			"Warning: on_shutdown() is already in progress\n");
 		return 0;


### PR DESCRIPTION
Older versions printed warning to console, now this is done only when
called as on_shutdown().

Part of #6