### PR TITLE
hot reload for all lua handlers

### DIFF
--- a/examples/hot_reload_multi_handler.lua
+++ b/examples/hot_reload_multi_handler.lua
@@ -1,0 +1,82 @@
+box.cfg{
+    listen = 3306,
+    wal_mode = 'none',
+    checkpoint_interval = 0,
+}
+
+local s = box.schema.space.create('tester')
+s:format({
+    {name = 'id', type = 'unsigned'},
+    {name = 'desc', type = 'string'},
+})
+local index = s:create_index('primary', {
+    type = 'tree',
+    parts = {'id'}
+})
+
+s:insert{1, 'First'}
+s:insert{2, 'Second'}
+
+local http = require 'httpng'
+local fiber = require 'fiber'
+
+local touch_db = function()
+    local tuple = s:get(2)
+end
+
+local foo_handler = function(req, io)
+    touch_db()
+    return {
+        status = 200,
+        body = 'foo',
+    }
+end
+
+local alt_foo_handler = function(req, io)
+    touch_db()
+    return {
+        status = 200,
+        body = 'FOO',
+    }
+end
+
+local bar_handler = function(req, io)
+    touch_db()
+    return {
+        status = 200,
+        body = 'bar',
+    }
+end
+
+local alt_bar_handler = function(req, io)
+    touch_db()
+    return {
+        status = 200,
+        body = 'BAR',
+    }
+end
+
+local config = {
+    threads = 4,
+    listen =  { { port = 8080 } },
+}
+
+::again::
+
+print 'Using foo..'
+config.handler = foo_handler;
+config.sites = {
+    {path = '/subdir',       handler = alt_foo_handler},
+}
+http.cfg(config)
+fiber.sleep(0.1)
+
+print 'Using bar..'
+config.sites = {
+    {path = '/subdir',       handler = alt_bar_handler},
+}
+config.handler = bar_handler;
+http.cfg(config)
+
+fiber.sleep(0.1)
+goto again


### PR DESCRIPTION
Hot reload code is now integrated into cfg(), this way there is less
copy-paste and we can check everything for sanity (not everything is
checked yet for easier merging). All Lua handlers are now replaced but
this is not being done atomically or efficiently.

Some parameters from new configuration are used before everything is
checked for sanity (to be improved later).

Also fixed some memory/resource leaks when initialization fails due to
invalid parameters.

Part of #18