### PR TITLE
libh2o native file hosting (prototype)

### DIFF
--- a/examples/files1/hello.txt
+++ b/examples/files1/hello.txt
@@ -1,0 +1,1 @@
+Hello, World! from libh2o-hosted file #1

--- a/examples/files2/hello.txt
+++ b/examples/files2/hello.txt
@@ -1,0 +1,1 @@
+Hello, World! from libh2o-hosted file #2

--- a/examples/native_files.lua
+++ b/examples/native_files.lua
@@ -1,0 +1,19 @@
+local http = require 'httpng'
+local fiber = require 'fiber'
+
+local lua_sites = { {path = '/files'} }
+local cfg = {
+    threads = 4,
+    sites = lua_sites,
+}
+
+::restart::
+lua_sites[1].handler = 'examples/files1'
+http.cfg(cfg)
+fiber.sleep(1)
+
+lua_sites[1].handler = 'examples/files2'
+http.cfg(cfg)
+fiber.sleep(1)
+
+goto restart

--- a/tests/all.lua
+++ b/tests/all.lua
@@ -123,7 +123,8 @@ g_wrong_config.test_handler_is_not_a_function = function()
 end
 
 g_wrong_config.test_sites_handler_is_not_a_function = function()
-    t.assert_error_msg_content_equals('sites[].handler is not a function',
+    t.assert_error_msg_content_equals(
+        'sites[].handler is not a function or string',
         http.cfg, { sites = { { path = '/', handler = 42 }, } })
 end
 


### PR DESCRIPTION
API is still old "sites" (to be replaced).
Folders only, not individual files.
Not configurable - no MIME types, compression, ETag...
Shutdown and hot reload work but you can't replace Lua handler with
native Lua handler and vice versa, remove path first.

Part of #38