### PR TITLE
build: drop unused msgpuck submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,6 @@
 [submodule "third_party/h2o"]
 	path = third_party/h2o
 	url = https://github.com/tarantool/h2o.git
-[submodule "third_party/msgpuck"]
-	path = third_party/msgpuck
-	url = https://github.com/tarantool/msgpuck.git
 [submodule "third_party/xtm"]
 	path = third_party/xtm
 	url = https://github.com/tarantool/xtm.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,7 +78,6 @@ set(USE_STATIC_WSLAY ON)
 
 add_subdirectory(third_party/h2o EXCLUDE_FROM_ALL)
 add_subdirectory(third_party/xtm EXCLUDE_FROM_ALL)
-add_subdirectory(third_party/msgpuck EXCLUDE_FROM_ALL)
 
 #set(HTTPNG_USE_LIBUV ON)
 


### PR DESCRIPTION
It seems unused (at least for now). So let's just drop this submodule.